### PR TITLE
Enable Cloudflare Web Analytics

### DIFF
--- a/about.html.j2
+++ b/about.html.j2
@@ -107,7 +107,16 @@
     <a href="https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#data-collection" target="_blank">GitHub Pages</a>.
     Please refer to the
     <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank">GitHub Privacy Statement</a>
-    for more information. Our emails don’t use any form of tracking.
+    for more information.
+
+    We use
+    <a href="https://www.cloudflare.com/web-analytics/" target="_blank">Cloudflare Web Analytics</a>
+    to measure our outreach. Cloudflare Web Analytics does not use any
+    client-side state, such as cookies or localStorage, to collect usage
+    metrics. We also don’t “fingerprint” individuals via their IP address, User
+    Agent string, or any other data for the purpose of displaying analytics.
+
+    Our emails don’t use any form of tracking.
 
   <p>The PostgreSQL Development conference is organized by <a href="https://www.pgevents.ca">Slonik Events Canada</a>
    which follows the <a href="https://www.pgevents.ca/about/privacypolicy/">Slonik Events Canada Privacy Policy</a>

--- a/base.html.j2
+++ b/base.html.j2
@@ -15,6 +15,9 @@
 <!-- https://stackoverflow.com/questions/14389566/stop-css-transition-from-firing-on-page-load -->
 <script> </script>
 
+<!-- Cloudflare Web Analytics -->
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "3477571408f745a6893267f9dbd8c6c7"}'></script>
+
 {# Metadata #}
 <meta name="author" content="Slonik Events Canada">
 <meta name="description" content="{{ full_name }} {{ year }}">
@@ -105,7 +108,7 @@
       <li><a href="{{ "cfp.html" | link }}">Call For Papers</a>
       <li><a href="{{ "registration.html" | link }}">Registration</a>
       <li><a href="{{ "sponsors.html" | link }}">Sponsors</a>
-      <li><a href="{{ "sponsor-levels.html" | link }}">Sponsorship Opportunities</a>      
+      <li><a href="{{ "sponsor-levels.html" | link }}">Sponsorship Opportunities</a>
       <li><a href="{{ "about.html" | link }}">About</a>
       <li><a href="{{ "contact.html" | link }}">Contact</a>
     </menu>


### PR DESCRIPTION
Currently, the metrics are only available to me, although I believe that I can share access with the team if I use my `@pgconf.dev` to create a new Cloudflare account.

See https://www.cloudflare.com/web-analytics/ for privacy information. Relevant blurb copied here:

> Popular analytics vendors glean visitor and site data in return for web analytics. With business models driven by ad revenue, many analytics vendors track visitor behavior on your website and create buyer profiles to retarget your visitors with ads. This is not Cloudflare’s model.
>
> Building technologies with data privacy in mind is a core tenet of Cloudflare’s mission to help build a better Internet. With Cloudflare, you don’t have to sacrifice your visitor privacy to get essential and accurate metrics on the usage of your website.
>
> Cloudflare Web Analytics does not use any client-side state, such as cookies or localStorage, to collect usage metrics. We also don’t “fingerprint” individuals via their IP address, User Agent string, or any other data for the purpose of displaying analytics.