### PR TITLE
Add Code of Conduct page

### DIFF
--- a/about.html.j2
+++ b/about.html.j2
@@ -97,7 +97,7 @@
     </li>
 
     <li>All attendees will be required to follow the
-      <a href="https://www.postgresql.org/about/policies/coc/" target="_blank">PostgreSQL Code of Conduct</a>.
+      <a href="/coc" target="_blank">Code of Conduct</a>.
     </li>
   </ul>
 

--- a/base.html.j2
+++ b/base.html.j2
@@ -110,6 +110,7 @@
       <li><a href="{{ "sponsors.html" | link }}">Sponsors</a>
       <li><a href="{{ "sponsor-levels.html" | link }}">Sponsorship Opportunities</a>
       <li><a href="{{ "about.html" | link }}">About</a>
+      <li><a href="{{ "/coc" | link }}">Code of Conduct</a>
       <li><a href="{{ "contact.html" | link }}">Contact</a>
     </menu>
   </nav>

--- a/coc/index.html.j2
+++ b/coc/index.html.j2
@@ -42,12 +42,12 @@ If a participant engages in harassing behavior, the conference organizers will w
 </p>
 Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance. Decisions regarding appropriate assistance will be at the sole discretion of the conference committee.
 </p>
-<p>
+
 <ul>
     <li>For emergencies: 911</li>    
     <li>PGConf.dev Conference Committee email: <a href="mailto:contact@pgconf.dev">contact@pgconf.dev</a></li>
   </ul>
-</p>
+
 <p>
 All participants are expected to adhere to this policy at all conference venues and conference-related social events.
 </p>
@@ -62,5 +62,6 @@ All participants are expected to adhere to this policy at all conference venues 
     <figure class="person">      
       <figcaption>Masahiko Sawada</figcaption>
     </figure>
+  </div>
 
 {%endblock%}

--- a/coc/index.html.j2
+++ b/coc/index.html.j2
@@ -23,10 +23,7 @@
 {% block main %}
   <h1>Code of Conduct</h1>
 
-  <p class="lead">
-
-PGConf.dev, as a PostgreSQL Community Conference, has adopted the <a href="https://www.postgresql.org/about/policies/coc/">PostgreSQL Code Of Conduct policy</a>. Please be sure to review that policy.
-</p>
+  
 <p>
 PGConf.dev is dedicated to providing a harassment-free conference experience for everyone. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks.
 </p>

--- a/coc/index.html.j2
+++ b/coc/index.html.j2
@@ -1,0 +1,66 @@
+{% set title = "Code of Conduct" %}
+{% extends "base.html.j2" %}
+
+{% block head %}
+  <style>
+    .person {
+      border-radius: var(--border-radius);
+      border: var(--border-width) solid var(--mute-border-color);
+      max-width: 200px;
+      overflow: hidden;
+    }
+
+    .person > figcaption {
+      font-family: var(--header-font);
+      letter-spacing: 0.03125em;
+      padding-inline: 1rem;
+      text-align: left;
+      text-transform: uppercase;
+    }
+  </style>
+{% endblock %}
+
+{% block main %}
+  <h1>Code of Conduct</h1>
+
+  <p class="lead">
+
+PGConf.dev, as a PostgreSQL Community Conference, has adopted the <a href="https://www.postgresql.org/about/policies/coc/">PostgreSQL Code Of Conduct policy</a>. Please be sure to review that policy.
+</p>
+<p>
+PGConf.dev is dedicated to providing a harassment-free conference experience for everyone. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks.
+</p>
+<p>
+
+Conference participants violating this policy may be sanctioned or expelled from the conference without a refund at the discretion of the Code Of Conduct committee.
+</p>
+<p>
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing, photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately. Failure to comply will result in sanctions and/or ejection from the conference without a refund.
+</p>
+<p>
+If a participant engages in harassing behavior, the conference organizers will work with the Code Of Conduct Committee to decide what action to take, including but not limited to: warning the offender, expulsion from the conference with no refund, and/or referral to appropriate authorities. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the conference staff, including anyone on the conference committee, or the Code of Conduct committee, immediately.
+</p>
+Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance. Decisions regarding appropriate assistance will be at the sole discretion of the conference committee.
+</p>
+<p>
+<ul>
+    <li>For emergencies: 911</li>    
+    <li>PGConf.dev Conference Committee email: <a href="mailto:contact@pgconf.dev">contact@pgconf.dev</a></li>
+  </ul>
+</p>
+<p>
+All participants are expected to adhere to this policy at all conference venues and conference-related social events.
+</p>
+
+ <h2>Code of Conduct Committee</h2>
+
+  
+  <div class="flex">
+    <figure class="person">      
+      <figcaption>Stacey Haysler</figcaption>
+    </figure>
+    <figure class="person">      
+      <figcaption>Masahiko Sawada</figcaption>
+    </figure>
+
+{%endblock%}


### PR DESCRIPTION
This PR adds a code of conduct to the static site.

I note that we don't yet seem to have a code of conduct committee email setup so I've left that off for now.
