### PR TITLE
Extend Jinja2 with {% markdown %} ... {% endmarkdown %}

### DIFF
--- a/about.html.j2
+++ b/about.html.j2
@@ -20,36 +20,31 @@
   </style>
 {% endblock %}
 
-{% block main %}
-  <h1>About</h1>
+{% block main %}{% markdown %}
+  # About
 
-  <p class="lead">
-    The PostgreSQL Development Conference, aka “<abbr>PGConf.dev</abbr>”, is
-    where users, developers, and community organizers come together to focus on
-    <a href="https://www.postgresql.org" target="_blank">PostgreSQL</a>
-    development and community growth.
+  The PostgreSQL Development Conference, aka “<abbr>PGConf.dev</abbr>”, is where
+  users, developers, and community organizers come together to focus on
+  [PostgreSQL] development and community growth.
 
-  <p>PGConf.dev is the successor to
-    <a href="https://www.pgcon.org/" target="_blank">PGCon</a>, and focuses on
-    creating a fun and constructive environment for PostgreSQL contributors to
-    meet, collaborate, and learn from each other.
+  PGConf.dev is the successor to [PGCon], and focuses on creating a fun and
+  constructive environment for PostgreSQL contributors to meet, collaborate, and
+  learn from each other.
 
-  <p>PGConf.dev is made possible by the generous support of our sponsors, the
-    amazing content from our speakers, the volunteers who help to organize and
-    run the event, and the participation of the PostgreSQL contributor
-    community.
+  PGConf.dev is made possible by the generous support of our sponsors, the
+  amazing content from our speakers, the volunteers who help to organize and run
+  the event, and the participation of the PostgreSQL contributor community.
 
-  <p>Follow us on
-    <a href="https://twitter.com/pgconfdev" target="_blank"><i class="fa-brands fa-x-twitter"></i></a>
+  Follow us on
+    <a href="https://twitter.com/pgconfdev"><i class="fa-brands fa-x-twitter"></i></a>
     or
-    <a href="https://mastodon.social/@pgconfdev" rel="me" target="_blank"><i class="fa-brands fa-mastodon"></i></a>
+    <a href="https://mastodon.social/@pgconfdev" rel="me"><i class="fa-brands fa-mastodon"></i></a>
     for up date news about the event.
 
-  <h2>Organization Team</h2>
+  ## Organization Team
 
-  <p>PGConf.dev {{ year }} is organized in cooperation with
-    <a href="https://www.pgevents.ca/" target="_blank">Slonik Events Canada</a>
-    by the following people.
+  PGConf.dev {{ year }} is organized in cooperation with [Slonik Events Canada]
+  by the following people.
 
   <div class="flex">
     <figure class="person">
@@ -83,55 +78,53 @@
     </figure>
   </div>
 
-  <h2>Volunteering</h2>
+  ## Volunteering
 
-  <p>Please <a href="{{ "contact.html" | link }}">contact us</a> if you'd like
-    to help organize, or volunteer at, the conference. Volunteering is a great
-    way to get more involved in the community, and we'd be happy to have you.
+  Please [contact us] if you'd like to help organize, or volunteer at, the
+  conference. Volunteering is a great way to get more involved in the community,
+  and we'd be happy to have you.
 
-  <h2>Policies</h2>
+  ## Policies
 
-  <ul>
-    <li>This conference is a
-      <a href="https://www.postgresql.org/about/policies/conferences/" target="_blank">PostgreSQL Community event</a>.
-    </li>
+  - This conference is a [PostgreSQL Community Event].
+  - All attendees will be required to follow the [Code of Conduct].
 
-    <li>All attendees will be required to follow the
-      <a href="/coc" target="_blank">Code of Conduct</a>.
-    </li>
-  </ul>
+  ## Privacy
 
-  <h2>Privacy</h2>
+  This site is hosted on [GitHub Pages]. Please refer to the [GitHub Privacy
+  Statement] for more information.
 
-  <p>This site is hosted on
-    <a href="https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#data-collection" target="_blank">GitHub Pages</a>.
-    Please refer to the
-    <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement" target="_blank">GitHub Privacy Statement</a>
-    for more information.
+  We use [Cloudflare Web Analytics] to measure our outreach. Cloudflare Web
+  Analytics does not use any client-side state, such as cookies or localStorage,
+  to collect usage metrics. We also don’t "fingerprint" individuals via their IP
+  address, User Agent string, or any other data for the purpose of displaying
+  analytics.
 
-    We use
-    <a href="https://www.cloudflare.com/web-analytics/" target="_blank">Cloudflare Web Analytics</a>
-    to measure our outreach. Cloudflare Web Analytics does not use any
-    client-side state, such as cookies or localStorage, to collect usage
-    metrics. We also don’t “fingerprint” individuals via their IP address, User
-    Agent string, or any other data for the purpose of displaying analytics.
+  Our emails don’t use any form of tracking.
 
-    Our emails don’t use any form of tracking.
+  The PostgreSQL Development conference is organized by [Slonik Events Canada]
+  which follows the [Slonik Events Canada Privacy Policy].
 
-  <p>The PostgreSQL Development conference is organized by <a href="https://www.pgevents.ca">Slonik Events Canada</a>
-   which follows the <a href="https://www.pgevents.ca/about/privacypolicy/">Slonik Events Canada Privacy Policy</a>
+  ## Financial Disclosure
 
-  <h2>Financial Disclosure</h2>
+  PGConf.dev is financially supported by our generous sponsors and is
+  underwritten by [Slonik Events Canada], a Canadian non-profit organization
+  incorporated expressly to organize this conference. All proceeds belong to
+  Slonik Events Canada and will be used in accordance with its [by-laws] to
+  support the PostgreSQL community.
 
-  <p>PGConf.dev is financially supported by our generous sponsors and is
-    underwritten by
-    <a href="https://www.pgevents.ca/" target="_blank">Slonik Events Canada</a>,
-    a Canadian non-profit organization incorporated expressly to organize this
-    conference. All proceeds belong to Slonik Events Canada and will be used in
-    accordance with its
-    <a href="https://www.pgevents.ca/media/local/pdf/slonik-events-bylaws-2023.pdf" target="_blank">by-laws</a>
-    to support the PostgreSQL community.
+  Organizers and volunteers receive no remuneration except free attendance to
+  the conference.
 
-  <p>Organizers and volunteers receive no remuneration except free attendance to
-    the conference.
-{%endblock%}
+  [PostgreSQL]: https://www.postgresql.org
+  [PGCon]: https://www.pgcon.org/
+  [contact us]: {{ "/contact.html" | link }}
+  [PostgreSQL Community Event]: https://www.postgresql.org/about/policies/conferences/
+  [Code of Conduct]: /coc
+  [GitHub Pages]: https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#data-collection
+  [GitHub Privacy Statement]: https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement
+  [Cloudflare Web Analytics]: https://www.cloudflare.com/web-analytics/
+  [Slonik Events Canada]: https://www.pgevents.ca
+  [Slonik Events Canada Privacy Policy]: https://www.pgevents.ca/about/privacypolicy/
+  [by-laws]: https://www.pgevents.ca/media/local/pdf/slonik-events-bylaws-2023.pdf
+{% endmarkdown %}{% endblock %}

--- a/base.html.j2
+++ b/base.html.j2
@@ -15,6 +15,21 @@
 <!-- https://stackoverflow.com/questions/14389566/stop-css-transition-from-firing-on-page-load -->
 <script> </script>
 
+<!-- Add the target="_blank" attribute to all external links -->
+<script>
+  window.addEventListener("DOMContentLoaded", (e) => {
+    for (const link of document.links) {
+      if (!["http:", "https:"].includes(link.protocol))
+        continue;
+      if (link.host == "" || link.host == location.host)
+        continue;
+      if (link.target != "")
+        continue;
+      link.target = "_blank";
+    }
+  });
+</script>
+
 <!-- Cloudflare Web Analytics -->
 <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "463d71d19a5a44428cc69b733b96e8ef"}'></script>
 
@@ -85,14 +100,14 @@
 
     <h4><a href="{{ "sponsors.html" | link }}">Gold Sponsors</a></h4>
     {% for sponsor in gold %}
-      <a href="{{ sponsor.url }}" target="_blank">
+      <a href="{{ sponsor.url }}">
         <img src="{{ ("static/logo/" + sponsor.image) | link }}" alt="{{ sponsor.name }}">
       </a>
     {% endfor %}
 
     <h4><a href="{{ "sponsors.html" | link }}">Silver Sponsors</a></h4>
     {% for sponsor in silver %}
-      <a href="{{ sponsor.url }}" target="_blank">
+      <a href="{{ sponsor.url }}">
         <img src="{{ ("static/logo/" + sponsor.image) | link }}" alt="{{ sponsor.name }}">
       </a>
     {% endfor %}

--- a/contact.html.j2
+++ b/contact.html.j2
@@ -1,25 +1,17 @@
-{% set title = "Contact Us" %} 
+{% set title = "Contact Us" %}
 {% extends "base.html.j2" %}
 
-{% block main %}
-  <h1>Contact Us</h1>
+{% block main %}{% markdown %}
+  # Contact Us
 
-  <p class="lead" style="text-align: center;">We'd love to hear from you!
+  <p style="text-align: center;">We'd love to hear from you!
 
-  <p>If you have any questions, comments or just want to say hi feel free to
-    get in touch with us at
-    <a href="mailto:contact@pgconf.dev">contact@pgconf.dev</a>. You can also
-    follow us on
+  If you have any questions, comments or just want to say hi feel free to get in
+  touch with us at contact@pgconf.dev. You can also follow us on
+  <a href="https://twitter.com/pgconfdev"><i class="fa-brands fa-x-twitter"></i></a>
+  or
+  <a href="https://mastodon.social/@pgconfdev" rel="me"><i class="fa-brands fa-mastodon"></i></a>
+  for up date news about the event.
 
-    <a href="https://twitter.com/pgconfdev">
-      <i class="fa-brands fa-x-twitter"></i></a>
-
-    or
-
-    <a href="https://mastodon.social/@pgconfdev" rel="me">
-      <i class="fa-brands fa-mastodon"></i></a>
-
-    for up date news about the event.
-
-  <p>During the event, the registration desk will be staffed at all times.
-{% endblock %}
+  During the event, the registration desk will be staffed at all times.
+{% endmarkdown %}{% endblock %}

--- a/graphical-schedule.html.j2
+++ b/graphical-schedule.html.j2
@@ -111,12 +111,12 @@
     {{ time("08:30", "12:30") }}
 
     <li class="workshop" {{ slot("a", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/314/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/314/">
         Developer Meeting (Invite Only)
       </a>
 
     <li class="workshop" {{ slot("b", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/241/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/241/">
         Extension Ecosystem Summit
       </a>
 
@@ -133,22 +133,22 @@
     {{ time("14:00", "15:30") }}
 
     <li class="workshop" {{ slot("a", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/265/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/265/">
         Advanced Patch Feedback Session
       </a>
 
     <li class="workshop" {{ slot("b", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/">
         Community Summit: Microconference 1
       </a>
 
     <li class="workshop" {{ slot("c", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/">
         Community Summit: Microconference 2
       </a>
 
     <li class="workshop" {{ slot("d", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/">
         Community Summit: Microconference 3
       </a>
 
@@ -165,17 +165,17 @@
     {{ time("16:00", "17:30") }}
 
     <li class="workshop" {{ slot("a", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/265/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/265/">
         Advanced Patch Feedback Session
       </a>
 
     <li class="workshop" {{ slot("b", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/">
         Community Summit: Microconference 4
       </a>
 
     <li class="workshop" {{ slot("c", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/404/">
         Community Summit: Microconference 5
       </a>
 
@@ -187,12 +187,12 @@
     {% set ns.latest_slot = "1830" -%}
 
     <li {{ slot("a", "b", room="O") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/347/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/347/">
         Community Meet and Eat
       </a>
 
     <li {{ slot("c", "d", room="O") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/269/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/269/">
         Social Run (and Dinner)
       </a>
   </ul>
@@ -210,7 +210,7 @@
       Breakfast
 
     <li class="social" {{ slot("d") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/313/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/313/">
         Student Breakfast
       </a>
 
@@ -227,19 +227,19 @@
     {{ time("10:00", "10:50") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/436/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/436/">
         Investigating Multithreaded PostgreSQL<br>
         <small>(Thomas Munro)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/331/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/331/">
         Adventures in Extension Packaging<br>
         <small>(David E. Wheeler)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/256/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/256/">
         Exploring the benefits of learned indexes in PostgreSQL: Theory and Implementation<br>
         <small>(GARY W EVANS, Nishchay Kothari)</small>
       </a>
@@ -252,19 +252,19 @@
     {{ time("11:30", "12:20") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/271/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/271/">
         What is new in C and POSIX?<br>
         <small>(Peter Eisentraut)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/410/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/410/">
         The trouble with extensions<br>
         <small>(Marco Slot)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/293/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/293/">
         Revisiting XTM: A Practical Case Study Highlighting Its Needs<br>
         <small>(Yuya Watari)</small>
       </a>
@@ -272,19 +272,19 @@
     {{ time("12:30", "12:55") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/301/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/301/">
         Compiling Postgres to WASM with PGlite<br>
         <small>(Sam Willis)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/388/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/388/">
         postgresql.org: The hidden parts<br>
         <small>(Magnus Hagander)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/281/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/281/">
         The Present and Future of VACUUM in PostgreSQL<br>
         <small>(Masahiko Sawada)</small>
       </a>
@@ -302,19 +302,19 @@
     {{ time("14:00", "14:50") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/254/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/254/">
         Committer Review: An Exercise in Paranoia<br>
         <small>(Robert Haas)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/229/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/229/">
         Multidimensional search strategies for composite B-Tree indexes<br>
         <small>(Peter V Geoghegan)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/363/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/363/">
         ChatGPT Ain’t Got $%@& On Me! Next Generation Automated Database Tuning<br>
         <small>(William Zhang)</small>
       </a>
@@ -322,19 +322,19 @@
     {{ time("15:00", "15:50") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/433/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/433/">
         Scaling Postgres to the next level at OpenAI<br>
         <small>(Bohan Zhang)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/276/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/276/">
         Experimenting with a Global Index in PostgreSQL: Design, Implementation, and Challenges<br>
         <small>(Dilip Kumar)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/385/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/385/">
         Designing and implementing a monitoring feature in PostgreSQL<br>
         <small>(Rahila Syed)</small>
       </a>
@@ -347,19 +347,19 @@
     {{ time("16:30", "16:55") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/444/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/444/">
         Tracking plan shapes over time with Plan IDs, and a new pg_stat_plans<br>
         <small>(Lukas Fittl)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/384/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/384/">
         Debugging Data Corruption in PostgreSQL<br>
         <small>(Palak Chaturvedi)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/372/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/372/">
         PostgreSQL container groups, aka cgroups down the road.<br>
         <small>(Cédric Villemain)</small>
       </a>
@@ -367,7 +367,7 @@
     {{ time("16:30", "17:30", synthetic=True) }}
 
     <li class="talk" {{ slot("d", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/345/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/345/">
         Crafting exploits for historical CVEs<br>
         <small>(Andrey Borodin)</small>
       </a>
@@ -375,19 +375,19 @@
     {{ time("17:00", "17:25") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/440/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/440/">
         What 10 Postgres Major Contributors Did to Become a Hacker<br>
         <small>(Claire Giordano)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/364/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/364/">
         Reproducible Postgres<br>
         <small>(Javier Maestro, Alvaro Hernandez)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/311/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/311/">
         Fast-path locking improvements in PG18<br>
         <small>(Tomas Vondra)</small>
       </a>
@@ -418,26 +418,26 @@
       Breakfast
 
     <li {{ slot("d", room=none) }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/424/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/424/">
         Postgres Women Breakfast
       </a>
 
     {{ time("09:30", "10:20") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/286/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/286/">
         Changing shared_buffers on the fly<br>
         <small>(Dmitrii Dolgov, Ashutosh Bapat)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/228/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/228/">
         My Journey in PostgreSQL bug fixing<br>
         <small>(Bertrand Drouvot)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/240/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/240/">
         Application Development Challenges with Postgres<br>
         <small>(Dian Fay)</small>
       </a>
@@ -450,19 +450,19 @@
     {{ time("11:00", "11:25") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/353/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/353/">
         Problems with logical decoding — an end-user’s perspective<br>
         <small>(Polina Bungina)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/379/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/379/">
         What does moving to Pull Requests look like? The nginx story<br>
         <small>(Alastair Turner)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/376/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/376/">
         Rethinking PostgreSQL Performance in the Age of Monster Hardware<br>
         <small>(Lætitia AVROT)</small>
       </a>
@@ -470,19 +470,19 @@
     {{ time("11:30", "12:20") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/430/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/430/">
         What went wrong with AIO<br>
         <small>(Andres Freund)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/245/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/245/">
         Detection and resolution of conflicts in logical replication<br>
         <small>(Zhijie Hou, Ajin Cherian)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/346/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/346/">
         Switching between query plans in real time (Switch Join)<br>
         <small>(Alena Rybakina)</small>
       </a>
@@ -501,19 +501,19 @@
     {{ time("13:30", "14:20") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/446/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/446/">
         Vector search is now boring, but PostgreSQL has ways to go<br>
         <small>(Jonathan Katz)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/359/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/359/">
         Improving scalability; Reducing overhead in shared memory<br>
         <small>(Matthias van de Meent)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/260/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/260/">
         Advanced testing with Injection Points<br>
         <small>(Michael Paquier)</small>
       </a>
@@ -521,19 +521,19 @@
     {{ time("14:30", "14:55") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/318/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/318/">
         What can Postgres learn from DuckDB?<br>
         <small>(Jelte Fennema-Nio)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/287/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/287/">
         Foreign Key Joins<br>
         <small>(Vik Fearing)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/426/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/426/">
         Everything You Need to Know About Diversity in 25 Minutes<br>
         <small>(Stacey Haysler)</small>
       </a>
@@ -546,19 +546,19 @@
     {{ time("15:30", "16:20") }}
 
     <li class="talk" {{ slot("a") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/419/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/419/">
         Writing fast C code for a modern CPU (and applying it to PostgreSQL)<br>
         <small>(David Rowley)</small>
       </a>
 
     <li class="talk" {{ slot("b") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/414/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/414/">
         Re-engineering Postgres for Millions of Tenants<br>
         <small>(Gwen Shapira)</small>
       </a>
 
     <li class="talk" {{ slot("c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/343/" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/343/">
         Fraught Feedback: Trying and Failing to Implement Adaptive Behavior in Postgres<br>
         <small>(Melanie Plageman)</small>
       </a>
@@ -583,7 +583,7 @@
     {{ time("09:00", "10:00") }}
 
     <li {{ slot("a", "c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348">
         Unconference
       </a>
 
@@ -595,14 +595,14 @@
     {{ time("10:30", "11:30") }}
 
     <li {{ slot("a", "c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348">
         Unconference
       </a>
 
     {{ time("11:30", "12:30") }}
 
     <li {{ slot("a", "c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348">
         Unconference
       </a>
 
@@ -614,14 +614,14 @@
     {{ time("13:30", "14:30") }}
 
     <li {{ slot("a", "c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348">
         Unconference
       </a>
 
     {{ time("14:30", "15:30") }}
 
     <li {{ slot("a", "c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348">
         Unconference
       </a>
 
@@ -633,7 +633,7 @@
     {{ time("16:00", "17:00") }}
 
     <li {{ slot("a", "c") }}>
-      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348" target="_blank">
+      <a href="https://www.pgevents.ca/events/pgconfdev2025/schedule/session/348">
         Unconference
       </a>
 

--- a/registration.html.j2
+++ b/registration.html.j2
@@ -1,135 +1,65 @@
 {% set title = "Registration" %}
 {% extends "base.html.j2" %}
 
-{% block head %}
-  <style>
-    dd {
-      margin-inline-start: 1.5rem;
-    }
+{% block main %}{% markdown %}
+  # Registration
 
-    .side-by-side {
-      grid-template-columns: none;
-    }
+  PGConf.dev is an annual event where users, developers, and community
+  organizers come together to focus on PostgreSQL development and community
+  growth. This event is a strategic gathering of the PostgreSQL community that
+  takes place before development begins.
 
-    @media (min-width: 768px) {
-      .side-by-side {
-        align-items: start;
-        grid-template-columns: 1fr auto;
-      }
-    }
-  </style>
-{% endblock %}
+  | Ticket  |     Price | Description                       |
+  | ------- | --------: | --------------------------------- |
+  | Regular |  $500 CAD | Normal conference attendance      |
+  | Student |   $75 CAD | Students with proof of enrollment |
+  | Speaker | No charge | Free for confirmed speakers       |
 
-{% block main %}
-  <h1>Registration</h1>
-<div>
-  <p class="lead">
-    PGConf.dev is an annual event where users, developers, and community organizers come together to focus on PostgreSQL development and community growth.
+  A 5% GST and 9.9975% QST tax applies on top of the above ticket prices.
 
-This event is a strategic gathering of the PostgreSQL community that takes place before development begins.
+  <p style="margin-block: 2rem; text-align: center;">
+    <a href="https://www.pgevents.ca/events/pgconfdev2025/register/" role="button">Register</a>
 
-</p>
+  ---
 
+  ## Cancellation
 
-    <div>
-    <table>
-    <thead>
-        <tr>
-            <th>Ticket</th>
-            <th>Price</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-        <td>Regular</td>
-        <td>$500 CAD</td>
-        <td>Normal conference attendance</td>
-        </tr>
-        <tr>
-            <td>Student</td>
-            <td>$75 CAD</td>
-            <td>For anyone enrolled in a higher level education program with a valid
-        and current Student ID or proof of enrollment.</td>
-        </tr>
-        <tr>
-            <td>Speaker</td>
-            <td>$0</td>
-            <td>Confirmed speakers get free registration</td>
-        </tr>
-
-    </tbody>
-    </table>
-
-    <p>A 5% GST and 9.9975% QST tax applies on top of the above ticket prices<p>
-      <p style="margin-block: 2rem; text-align: center;">
-    <a href="https://www.pgevents.ca/events/pgconfdev2025/register//" role="button">Register</a>
-    </div>
-
-    <hr>
-
-  <h2 id="cancellation">Cancellation</h2>
-<p>
-  If you need to cancel your registration after you have paid, please
- <a href="mailto:contact@pgconf.dev">contact@pgconf.dev</a> for manual handling.  The
-  refund we can offer depends on when
-  you cancel so please cancel as soon as you know you won't be able to make
+  If you need to cancel your registration after you have paid, please email
+  contact@pgconf.dev for manual handling. The refund we can offer depends on
+  when you cancel so please cancel as soon as you know you won't be able to make
   it to the event. The available refund levels are:
-</p>
-<table class="cancellation">
-  <thead>
-    <tr>
-      <th>Cancel on or before</th>
-      <th>Refund</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>        
-        <td>2025-04-08</td>
-        <td>100%<td>
-    </tr>
-    <tr>        
-        <td>2025-04-22</td>
-        <td>50%<td>
-    </tr>
-    <tr>        
-        <td>2025-04-29</td>
-        <td>25%<td>
-    </tr>
-  </tbody>
-</table>
-<p>
-  Cancellations on or after 2025-04-30, as well as any for which
-  a visa invitation letter has been provided, cannot be refunded.
-</p>
-<p>
-  All cancellations incur a $30(plus tax) administration fee.
-</p>
 
-<hr>
+  | Cancel On or Before                                            | Refund |
+  | -------------------------------------------------------------- | ------ |
+  | <time datetime="2025-04-08">April  8<sup>th</sup>, 2025</time> |   100% |
+  | <time datetile="2025-04-22">April 22<sup>nd</sup>, 2025</time> |    50% |
+  | <time datetime="2025-04-29">April 29<sup>th</sup>, 2025</time> |    25% |
 
-<h2 id="student">Students</h2>
-<p>
-  We require proof of current enrollment such as a current student identification, or
-  some similar proof of enrolment. If you are unsure if you qualify for a
-  student ticket, <a href="mailto:contact@pgconf.dev">contact@pgconf.dev</a> and we will
-  give a definitive answer.
-</p>
-<p>We will contact you after your register and ask you to provide proof of your student status.
-The number of tickets reserved for students is limited, we recommend students register early.
-Students who register after the student tickets have been sold out will need to buy a full price regular registration
-</p>
+  Cancellations on or after <time datetime="2025-04-30">April 30<sup>th</sup>,
+  2025</time>, as well as cancellations for which a visa invitation letter has
+  already been provided, cannot be refunded.
 
-<h3>Your Data</h3>
-<p>
+  All cancellations incur a $30 CAD (plus tax) administration fee.
+
+  ## Students
+
+  We require proof of current enrollment such as a current student
+  identification, or some similar proof of enrollment. If you are unsure if you
+  qualify for a student ticket, email contact@pgconf.dev and we will give a
+  definitive answer.
+
+  We will contact you after you register and ask you to provide proof of your
+  student status. The number of tickets reserved for students is limited, we
+  recommend students register early. Students who register after the student
+  tickets have been sold out will need to buy a full price regular
+  registration.
+
+  ## Your Data
+
   When registering for the conference, we will ask for personal information
-  such as name and address, but also your dietary requirements.  For
-  information on how this data is stored and processed, see the
-  <a href="https://www.pgevents.ca/about/privacypolicy/">Slonik Events Canada
-    Privacy Policy</a>.
-</p>
-<span class="anchor" id="iban"></span>
+  such as name and address, but also your dietary requirements. For
+  information on how this data is stored and processed, see the [Slonik Events
+  Canada Privacy Policy]
 
-
-</div>
-{%endblock%}
+  [Slonik Events Canada Privacy Policy]: https://www.pgevents.ca/about/privacypolicy/
+{% endmarkdown %}{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Jinja2>=3.1.4
 PyYAML>=6.0.2
+cmarkgfm>=2024.1.14
 invoke>=2.2.0

--- a/sponsor-levels.html.j2
+++ b/sponsor-levels.html.j2
@@ -24,11 +24,14 @@
   <h1>Call for Sponsors</h1>
 
   <p class="lead">
-    PGConf.dev is an annual event where users, developers, and community organizers come together to focus on PostgreSQL development and community growth.
+    PGConf.dev is an annual event where users, developers, and community
+    organizers come together to focus on PostgreSQL development and community
+    growth.
 
-This event is a strategic gathering of the PostgreSQL community that takes place before development begins.
+    This event is a strategic gathering of the PostgreSQL community that takes
+    place before development begins.
 
-You can download the sponsorship prospectus <a href="/static/PGConf.dev 2025 - Sponsorship Prospectus.pdf">here</a>
+    You can download the sponsorship prospectus <a href="/static/PGConf.dev 2025 - Sponsorship Prospectus.pdf">here</a>
 
   <section class="side-by-side grid">
     <div>
@@ -38,7 +41,7 @@ You can download the sponsorship prospectus <a href="/static/PGConf.dev 2025 - S
         <li>PGConf.dev is not your typical PostgreSQL event!</li>
         <li>Your sponsorship directly impacts ongoing development of PostgreSQL, allowing of the PostgreSQL community leaders to meet in a single location and plan future releases.
 </li>
-        <li>Your sponsorship helps the PostgreSQL community to grow future community leaders and help them take on new roles in the community!</li>        
+        <li>Your sponsorship helps the PostgreSQL community to grow future community leaders and help them take on new roles in the community!</li>
       </ul>
     </div>
 
@@ -65,78 +68,70 @@ You can download the sponsorship prospectus <a href="/static/PGConf.dev 2025 - S
 
   <hr>
 
-  <h2 id="Gold">Gold $25,000 CAD</h2>
+  {% markdown %}
+    ## Gold $25,000 CAD
 
-  <p>Gold is the highest sponsorship we offer. As a Gold sponsor, you are a partner with us in helping to drive the ongoing development of the PostgreSQL community. Gold sponsor benefits include.
-  </p>
+    Gold is the highest sponsorship we offer. As a Gold sponsor, you are a
+    partner with us in helping to drive the ongoing development of the
+    PostgreSQL community. Gold sponsor benefits include.
 
-  
-  <ul>
-    <li>Five (5) complimentary registrations</li>
-    <li>Logo featured in the recorded session videos</li>
-    <li>Logo featured on conference t-shirt</li>
-    <li>Logo prominently featured in conference banner in foyer and common areas</li>
-    <li>Sponsor provided banners in the front of rooms for presentation talks</li>
-    <li>Logo featured in “hallway track” seating/sofa/tables in common area</li>
-    <li>Logo featured prominently on website</li>
-    <li>Allowing for one (1) large and one (1) small promotional item</li>
-    <li>Allowance for stickers on table by registration</li>
-    <li>Recognition by the presenters in the opening and closing sessions of the conference</li>
-    <li>Logo featured on to-be-determined PGConf.dev promotional take home item</li>
-    <li>Business description (1 paragraph) on conference website</li>
-    <li>Option to choose one individual sponsor benefit while supplies last:
-    <ul><li>Lanyards</li>
-    <li>Social event</li>
-    <li>Meals & coffee breaks</li>
-    <li>Keynote chair drop</li>
-    <li>Lightning talk chair drop</li>
-    </ul>
-    </li>
-  </ul>
-  <hr>
-  <h2 id="Silver">Silver $9,000 CAD</h2>
+    - Five (5) complimentary registrations
+    - Logo featured in the recorded session videos
+    - Logo featured on conference t-shirt
+    - Logo prominently featured in conference banner in foyer and common areas
+    - Sponsor provided banners in the front of rooms for presentation talks
+    - Logo featured in “hallway track” seating/sofa/tables in common area
+    - Logo featured prominently on website
+    - Allowing for one (1) large and one (1) small promotional item
+    - Allowance for stickers on table by registration
+    - Recognition by the presenters in the opening and closing sessions of the
+      conference
+    - Logo featured on to-be-determined PGConf.dev promotional take home item
+    - Business description (1 paragraph) on conference website
+    - Option to choose one individual sponsor benefit while supplies last:
+      - Lanyards
+      - Social event
+      - Meals & coffee breaks
+      - Keynote chair drop
+      - Lightning talk chair drop
 
-  <p>
-  Silver is a high visibility sponsorship that helps support PGConf.dev activities in helping to develop and grow PostgreSQL. Silver benefits include:
-  </p>
+    ---
 
-  
-  <ul>
-    <li>Two (2) complimentary registrations</li>    
-    <li>Logo featured on conference t-shirt</li>
-    <li>Logo featured in conference banner in foyer and common areas</li>    
-    <li>Logo featured in “hallway track” standing tables in common area</li>
-    <li>Logo featured on website</li>
-    <li>Allowing for one (1) small promotional item</li>
-    <li>Allowance for stickers on table by registration</li>
-    <li>Recognition by the presenters in the opening and closing sessions of the conference</li>            
-    </ul>
-    </li>
-  </ul>
-  <hr>
+    ## Silver $9,000 CAD
 
-<h2 id="Bronze">Bronze $2,500 CAD</h2>
+    Silver is a high visibility sponsorship that helps support PGConf.dev
+    activities in helping to develop and grow PostgreSQL. Silver benefits
+    include:
 
-  <p>
-  Bronze sponsors lets you show your support for PGConf.dev. Bronze benefits include:
-  </p>
+    - Two (2) complimentary registrations
+    - Logo featured on conference t-shirt
+    - Logo featured in conference banner in foyer and common areas
+    - Logo featured in “hallway track” standing tables in common area
+    - Logo featured on website
+    - Allowing for one (1) small promotional item
+    - Allowance for stickers on table by registration
+    - Recognition by the presenters in the opening and closing sessions of the
+      conference
 
-  
-  <ul>
-    <li>One (1) complimentary registrations</li>        
-    <li>Logo featured in conference banner in foyer and common areas</li>        
-    <li>Logo featured on website</li>    
-    <li>Allowance for stickers on table by registration</li>    
-    </ul>
-    </li>
-  </ul>
-  <hr>
+    ---
 
-  <h2>Sponsorship Committee</h2>
-  <p>Please contact
-    <a href="mailto:sponsors@pgconf.dev">sponsors@pgconf.dev</a>
-    with any questions about sponsorship
+    ## Bronze $2,500 CAD
 
-    <p style="margin-block-start: 2rem; text-align: center;">
+    Bronze sponsors lets you show your support for PGConf.dev. Bronze benefits
+    include:
+
+    - One (1) complimentary registrations
+    - Logo featured in conference banner in foyer and common areas
+    - Logo featured on website
+    - Allowance for stickers on table by registration
+
+    ---
+
+    ## Sponsorship Committee
+
+    Please email sponsors@pgconf.dev with any questions about sponsorship.
+  {% endmarkdown %}
+
+  <p style="margin-block-start: 2rem; text-align: center;">
     <a href="https://www.pgevents.ca/events/sponsor/signup/pgconfdev2025/" role="button">Signup</a>
 {%endblock%}

--- a/sponsors.html.j2
+++ b/sponsors.html.j2
@@ -11,7 +11,7 @@
   <div class="flex">
     {% for sponsor in gold %}
     <figure class="sponsor">
-        <a href="{{ sponsor.url }}" target="_blank">
+        <a href="{{ sponsor.url }}">
             <img src="static/logo/{{ sponsor.image }}" alt="{{ sponsor.name }}" >
         </a>
         <div>{{ sponsor.description }}</div>
@@ -23,7 +23,7 @@
   <div class="flex">
     {% for sponsor in silver %}
     <figure class="sponsor">
-        <a href="{{ sponsor.url }}" target="_blank">
+        <a href="{{ sponsor.url }}">
             <img src="static/logo/{{ sponsor.image }}" alt="{{ sponsor.name }}" >
         </a>
       <div>{{ sponsor.description }}</div>
@@ -35,7 +35,7 @@
   <div class="flex">
     {% for sponsor in bronze %}
     <figure class="sponsor-bronze">
-        <a href="{{ sponsor.url }}" target="_blank">
+        <a href="{{ sponsor.url }}">
             <img src="static/logo/{{ sponsor.image }}" alt="{{ sponsor.name }}" >
         </a>
     </figure>

--- a/static/main.css
+++ b/static/main.css
@@ -87,7 +87,7 @@ body > main p {
   text-align: justify;
 }
 
-p.lead {
+main > h1 + p, .lead {
   font-size: 1.25em;
   font-weight: 300;
 }

--- a/venue.html.j2
+++ b/venue.html.j2
@@ -2,40 +2,60 @@
 {% extends "base.html.j2" %}
 
 {% block main %}
-  <h1>Welcome to Montreal!</h1>
+  {% markdown %}
+    # Welcome to Montreal!
 
-  <p class="lead">
-    PGConf.dev 2025 will be held at Plaza Centre-Ville, inside the “EVO”
+    PGConf.dev 2025 will be held at Plaza Centre-Ville, inside the "EVO"
     building at 777, boul  Robert-Bourassa, Montréal, QC, H3A 0B1.
 
-  <article>
-    <figure>
-      <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=-73.56381744146348%2C45.49910356368318%2C-73.56139272451402%2C45.50043083868488&amp;layer=mapnik&amp;marker=45.49976720509503%2C-73.56260508298874" style="aspect-ratio: 16 / 10; width: 100%;"></iframe>
-      <figcaption style="font-size: 0.8em;">
-        <a href="https://www.openstreetmap.org/?mlat=45.499767&amp;mlon=-73.562605#map=19/45.499767/-73.562605" target="_blank">View Larger Map</a>
-      </figcaption>
-    </figure>
-  </article>
+    <article>
+      <figure>
+        <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=-73.56381744146348%2C45.49910356368318%2C-73.56139272451402%2C45.50043083868488&amp;layer=mapnik&amp;marker=45.49976720509503%2C-73.56260508298874" style="aspect-ratio: 16 / 10; width: 100%;"></iframe>
+        <figcaption style="font-size: 0.8em;">
+          <a href="https://www.openstreetmap.org/?mlat=45.499767&amp;mlon=-73.562605#map=19/45.499767/-73.562605">View Larger Map</a>
+        </figcaption>
+      </figure>
+    </article>
 
-  <h2>Hotels</h2>
-    <p>
-    PGConf.dev has negotiated discounted rates with several hotels in Montreal. We recommend that you book your accommodations early, whether or not you're staying at one of the hotels below, as there are many activities around Montreal at this time of the year.
-    </p>
-  <h3>Alt Hotel Montreal</h3>
-  <p>
-  <a href="https://www.germainhotels.com/en/alt-hotel/montreal" target="_blank">The Alt Hotel</a> is located
-  at 120, rue Peel, approximately a 15 minute walk from the conference venue.  Rooms are available
-  starting at $239 CAD a night.  You can book with this <a href="https://reservation.germainhotels.com/ibe/details.aspx?propertyid=17532&nights=1&checkin=05/12/2025&group=2505SQLDEV&lang=en-us&adults=1&childAges=" target="blank">link</a>
-  Bookings with the above link must be made by <time datetime="2025-04-12">April 12, 2025</time>.  It might be possible to make bookings by phone or email using the code <kbd>2505SQLDEV</kbd> after this date. 
-  If your trying to book rooms adjacent to May 11-17 you might need call the hotel at <a href="tel:18558238120">1.855.823.8120</a> or email <a href="mailto:reservations.altmontreal@germainhotels.com">reservations.altmontreal@germainhotels.com</a>
-  </p>
+    ## Hotels
 
-  <h3>Le St Sulpice</h3>
-  <p>
-  <a href="https://www.lesaintsulpice.com/">Le Saint Sulpice</a> is a boutique hotel located in the old city. 
-  The hotel is at 414, rou Saint-Sulpice, approximately a 15 minute walk from the conference venue.
-  Rooms are available starting at $284 CAD a night.  You can book with this <a href="https://be.synxis.com/?Hotel=80196&Chain=17448&locale=en-US&group=2505SL">link</a>
-  before <time datetime="2025-03-28">March 28 2025</time>. It should be possible took rooms adjacent to the May 10-17 at their regular rate using the code 2505SL</p>
+    PGConf.dev has negotiated discounted rates with several hotels in Montreal.
+    We recommend that you book your accommodations early, whether or not you're
+    staying at one of the hotels below, as there are many activities around
+    Montreal at this time of the year.
+
+    ### Alt Hotel Montreal
+
+    The [Alt Hotel] is located at 120, rue Peel, approximately a 15 minute walk
+    from the conference venue. Rooms are available starting at $239 CAD a night.
+    You can [book the Alt Hotel here]. Bookings with the above link must be made
+    by <time datetime="2025-04-12">April 12<sup>th</sup>, 2025</time>.
+
+    It might be possible to make bookings by phone or email using the code
+    <kbd>2505SQLDEV</kbd> after this date. If you're trying to book rooms
+    adjacent to
+    <time datetime="2025-05-11">May 11<sup>th</sup></time>&ndash;<time datetime="2025-05-17">17<sup>th</sup></time>,
+    you might need call the hotel at [1.855.823.8120] or email
+    reservations.altmontreal@germainhotels.com.
+
+    ### Le St Sulpice
+
+    [Le Saint Sulpice] is a boutique hotel located in the old city. The hotel is
+    at 414, rou Saint-Sulpice, approximately a 15 minute walk from the
+    conference venue. Rooms are available starting at $284 CAD a night. You can
+    [book Le St Sulpice here] before
+    <time datetime="2025-03-28">March 28<sup>th</sup> 2025</time>. It should be
+    possible took rooms adjacent to
+    <time datetime="2025-05-10">May 10<sup>th</sup></time>&ndash;<time datetime="2025-05-17">17<sup>th</sup></time>
+    at their regular rate using the code <kbd>2505SL</kbd>.
+
+    [Alt Hotel]: https://www.germainhotels.com/en/alt-hotel/montreal
+    [book the Alt Hotel here]: https://reservation.germainhotels.com/ibe/details.aspx?propertyid=17532&nights=1&checkin=05/12/2025&group=2505SQLDEV&lang=en-us&adults=1&childAges=
+    [1.855.823.8120]: tel:+18558238120
+    [Le Saint Sulpice]: https://www.lesaintsulpice.com/
+    [book Le St Sulpice here]: https://be.synxis.com/?Hotel=80196&Chain=17448&locale=en-US&group=2505SL
+  {% endmarkdown %}
+
   <h2>Travel</h2>
 
   <div style="font-size: 0.875em;">
@@ -49,7 +69,7 @@
 
       <p>Montréal&ndash;Trudeau International Airport (YUL) is the nearest
         airport to the conference. It has
-        <a href="https://www.admtl.com/en/flights/direct-flights" target="_blank">direct flights</a>
+        <a href="https://www.admtl.com/en/flights/direct-flights">direct flights</a>
         to 151 destinations in 46 countries.
     </article>
 
@@ -62,19 +82,21 @@
       </header>
 
       <p>The conference is located two blocks from
-        <a href="https://garecentrale.ca/en" target="_blank">Montreal Central Station</a>,
+        <a href="https://garecentrale.ca/en">Montreal Central Station</a>,
         with service to both
-        <a href="https://www.viarail.ca" target="_blank">VIA Rail</a> and
-        <a href="https://www.amtrak.com/home.html" target="_blank">Amtrak</a>.
+        <a href="https://www.viarail.ca">VIA Rail</a> and
+        <a href="https://www.amtrak.com/home.html">Amtrak</a>.
     </article>
   </div>
 
-  <h2>Visa Information</h2>
+  {% markdown %}
+    ## Visa Information
 
-  <p>Most international travellers need either a visitor visa or an Electronic
-    Travel Authorization (<abbr>eTA</abbr>) to enter Canada.
-    <a href="https://ircc.canada.ca/english/visit/visas.asp" target="_blank">This tool</a>
-    will help you determine which applies to you.
+    Most international travellers need either a visitor visa or an Electronic
+    Travel Authorization (<abbr>eTA</abbr>) to enter Canada. [This
+    tool](https://ircc.canada.ca/english/visit/visas.asp) will help you
+    determine which applies to you.
+  {% endmarkdown %}
 
   <article>
     <main>
@@ -83,7 +105,7 @@
         <p>Citizens and permanent residents of the U.S. may enter Canada visa-free.
           U.S. Citizens must have a valid passport while lawful permanent residents
           must have the documents listed
-          <a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/entry-requirements-country.html#lawful-pr-us" target="_blank">here</a>.
+          <a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/entry-requirements-country.html#lawful-pr-us">here</a>.
       </details>
 
       <hr>
@@ -91,9 +113,9 @@
       <details>
         <summary>Electronic Travel Authorization (eTA)</summary>
         <p>Visitors from
-          <a href="https://ircc.canada.ca/english/visit/visas.asp" target="_blank">visa-exempt countries</a>
+          <a href="https://ircc.canada.ca/english/visit/visas.asp">visa-exempt countries</a>
           should apply for an eTA
-          <a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/eta/apply.html" target="_blank">here</a>.
+          <a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/eta/apply.html">here</a>.
           Most applications are approved quickly.
       </details>
 
@@ -102,14 +124,19 @@
       <details>
         <summary>Visitor Visa</summary>
         <p>Procedures for obtaining a visitor visa are available
-          <a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/about-visitor-visa.html" target="_blank">here</a>.
+          <a href="https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/about-visitor-visa.html">here</a>.
           This process can be lengthy and we advise that you start it as soon as you
           have decided that you will be attending the conference.
       </details>
     </main>
   </article>
 
-  <h2>Questions</h2>
-  <p>If you have any questions regarding your travel arrangements feel free to
-    <a href="/contact.html">contact us</a>, we are more than happy to assist you.
+  {% markdown %}
+    ## Questions
+
+    If you have any questions regarding your travel arrangements feel free to
+    [contact us], we are more than happy to assist you.
+
+    [contact us]: {{ "/contact.html" | link }}
+  {% endmarkdown %}
 {% endblock %}


### PR DESCRIPTION
This adds a `{% markdown %} ... {% endmarkdown %}` control structure to Jinja2 that renders ... using Markdown.

The specific flavor of Markdown used is GitHub Flavored Markdown, with all extensions except "tagfilter" and "tasklist" enabled, and with the unsafe, smart, normalize, footnotes, and table-prefer-style-attributes options.

To accommodate this change, the "lead" class is applied to any `<p>` element within `<main>` that immediately follows an `<h1>`. And a Javascript snippet is included in the base template that automatically adds `target="_blank"` to all external links.

The About, Contact, Registration, Sponsorship Opportunities, and Venue pages have been rewritten to use this feature.